### PR TITLE
v2.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,27 @@ final class EntryUpdateRequestHandler implements RequestHandlerInterface
 
 ## Useful to know
 
+### Get a current route
+
+#### Through Router
+
+> Available from version 2.12.
+
+```php
+$router->getMatchedRoute();
+```
+
+#### Through Request
+
+> Available from version 1.x, but wasn't documented before...
+
+```php
+$request->getAttribute('@route');
+
+// or
+$request->getAttribute(\Sunrise\Http\Router\RouteInterface::ATTR_ROUTE);
+```
+
 ### Generation a route URI
 
 ```php

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
     "scripts": {
         "test": [
             "phpcs",
-            "XDEBUG_MODE=coverage phpunit --coverage-text"
+            "XDEBUG_MODE=coverage phpunit --coverage-text --colors=always"
         ],
         "build": [
             "phpdoc -d src/ -t phpdoc/",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<phpunit colors="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
     <coverage>
         <include>
             <directory>./src</directory>

--- a/src/RouteCollection.php
+++ b/src/RouteCollection.php
@@ -149,18 +149,6 @@ class RouteCollection implements RouteCollectionInterface
     }
 
     /**
-     * Alias to the addMiddleware method
-     *
-     * @param MiddlewareInterface ...$middlewares
-     *
-     * @return RouteCollectionInterface
-     */
-    public function appendMiddleware(MiddlewareInterface ...$middlewares) : RouteCollectionInterface
-    {
-        return $this->addMiddleware(...$middlewares);
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function prependMiddleware(MiddlewareInterface ...$middlewares) : RouteCollectionInterface
@@ -170,6 +158,14 @@ class RouteCollection implements RouteCollectionInterface
         }
 
         return $this;
+    }
+
+    /**
+     * @deprecated 2.12.0 Use the addMiddleware method.
+     */
+    public function appendMiddleware(MiddlewareInterface ...$middlewares) : RouteCollectionInterface
+    {
+        return $this->addMiddleware(...$middlewares);
     }
 
     /**

--- a/src/Router.php
+++ b/src/Router.php
@@ -84,6 +84,13 @@ class Router implements MiddlewareInterface, RequestHandlerInterface, RequestMet
     private $middlewares = [];
 
     /**
+     * The router's matched route
+     *
+     * @var RouteInterface|null
+     */
+    private $matchedRoute = null;
+
+    /**
      * Gets the router host table
      *
      * @return array
@@ -113,6 +120,16 @@ class Router implements MiddlewareInterface, RequestHandlerInterface, RequestMet
     public function getMiddlewares() : array
     {
         return array_values($this->middlewares);
+    }
+
+    /**
+     * Gets the router's matched route
+     *
+     * @return RouteInterface|null
+     */
+    public function getMatchedRoute() : ?RouteInterface
+    {
+        return $this->matchedRoute;
     }
 
     /**
@@ -355,7 +372,9 @@ class Router implements MiddlewareInterface, RequestHandlerInterface, RequestMet
     {
         // lazy resolving of the given request...
         $routing = new CallableRequestHandler(function (ServerRequestInterface $request) : ResponseInterface {
-            return $this->match($request)->handle($request);
+            $route = $this->match($request);
+            $this->matchedRoute = $route;
+            return $route->handle($request);
         });
 
         $middlewares = $this->getMiddlewares();
@@ -375,6 +394,7 @@ class Router implements MiddlewareInterface, RequestHandlerInterface, RequestMet
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
         $route = $this->match($request);
+        $this->matchedRoute = $route;
 
         $middlewares = $this->getMiddlewares();
         if (empty($middlewares)) {

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -428,6 +428,8 @@ class RouterTest extends TestCase
                 $routes[1]->getPath()
             ));
 
+        $this->assertNotNull($router->getMatchedRoute());
+        $this->assertSame($routes[1]->getName(), $router->getMatchedRoute()->getName());
         $this->assertTrue($routes[1]->getRequestHandler()->isRunned());
     }
 
@@ -509,6 +511,8 @@ class RouterTest extends TestCase
                 $routes[2]->getPath()
             ));
 
+        $this->assertNotNull($router->getMatchedRoute());
+        $this->assertSame($routes[2]->getName(), $router->getMatchedRoute()->getName());
         $this->assertTrue($routes[2]->getRequestHandler()->isRunned());
     }
 


### PR DESCRIPTION
* A new method `Router::getMatchedRoute()` was added;
* The `RouteCollection::appendMiddleware()` method was marked as deprecated.