### PR TITLE
Add possibility to use psr/container 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": "^7.1|^8.0",
         "fig/http-message-util": "^1.1",
-        "psr/container": "^1.0",
+        "psr/container": "^1.0 || ^2.0",
         "psr/http-message": "^1.0",
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",
@@ -40,7 +40,7 @@
         "sunrise/coding-standard": "1.0.0",
         "sunrise/http-factory": "2.0.0",
         "doctrine/annotations": "^1.6",
-        "symfony/console": "^4.4",
+        "symfony/console": "^5.4",
         "symfony/event-dispatcher": "^4.4"
     },
     "autoload": {


### PR DESCRIPTION
This will let users to use containers compatible with [psr/container 2.x](https://github.com/php-fig/container/releases/tag/2.0.0).

Symfony console here was updated because older versions don't support v2.x yet.