### PR TITLE
v3.3 | Make OpenAPI generation reusable and support @var array item types for views

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,36 +1,54 @@
+# https://www.php.net/releases/index.php
+
 build:
-  image: default-bionic
+  image: default-jammy
   nodes:
     analysis:
       environment:
-        php: 8.3.16
+        php: '8.5.6'
       tests:
         override:
           - php-scrutinizer-run
     coverage:
       environment:
-        php: 8.3.16
+        php: '8.5.6'
+      dependencies:
+        before:
+          - pecl channel-update pecl.php.net
+          - pecl install pcov
       tests:
         override:
-          - command: XDEBUG_MODE=coverage php vendor/bin/phpunit --coverage-clover coverage.xml --cache-directory .
+          - command: php -d pcov.enabled=1 -d pcov.directory=src vendor/bin/phpunit --coverage-clover coverage.xml
             coverage:
               file: coverage.xml
               format: clover
+    php85:
+      environment:
+        php: '8.5.6'
+      tests:
+        override:
+          - command: composer test
+    php84:
+      environment:
+        php: '8.4.21'
+      tests:
+        override:
+          - command: composer test
     php83:
       environment:
-        php: 8.3.16
+        php: '8.3.16'
       tests:
         override:
           - command: composer test
     php82:
       environment:
-        php: 8.2.27
+        php: '8.2.27'
       tests:
         override:
           - command: composer test
     php81:
       environment:
-        php: 8.1.31
+        php: '8.1.31'
       tests:
         override:
           - command: composer test

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
   "require": {
     "php": ">=8.1",
     "fig/http-message-util": "^1.1",
+    "phpdocumentor/reflection-docblock": "^6.0",
     "psr/container": "^1.0 || ^2.0",
     "psr/event-dispatcher": "^1.0",
     "psr/http-factory": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "require": {
     "php": ">=8.1",
     "fig/http-message-util": "^1.1",
-    "phpdocumentor/reflection-docblock": "^6.0",
+    "phpdocumentor/reflection-docblock": "^5.6 || ^6.0",
     "psr/container": "^1.0 || ^2.0",
     "psr/event-dispatcher": "^1.0",
     "psr/http-factory": "^1.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,5 @@
 parameters:
+  reportUnmatchedIgnoredErrors: false
   ignoreErrors:
     - '#Cannot access an offset on mixed#'
     - '#Cannot access offset .* on mixed#'

--- a/phpstan.php-lt-83.neon
+++ b/phpstan.php-lt-83.neon
@@ -1,4 +1,3 @@
 parameters:
   ignoreErrors:
     - '#Call to an undefined static method ReflectionMethod::createFromMethodName\(\)#'
-  reportUnmatchedIgnoredErrors: false

--- a/phpstan.php-lt-83.neon
+++ b/phpstan.php-lt-83.neon
@@ -1,3 +1,4 @@
 parameters:
   ignoreErrors:
     - '#Call to an undefined static method ReflectionMethod::createFromMethodName\(\)#'
+  reportUnmatchedIgnoredErrors: false

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -22,6 +22,7 @@
     <MixedAssignment errorLevel="suppress" />
     <PossiblyUnusedMethod errorLevel="suppress" />
     <PossiblyUnusedProperty errorLevel="suppress" />
+    <PropertyNotSetInConstructor errorLevel="suppress" />
     <UnnecessaryVarAnnotation errorLevel="suppress" />
     <UnresolvableInclude errorLevel="suppress" />
     <UnusedClass errorLevel="suppress" />

--- a/resources/definitions/openapi.php
+++ b/resources/definitions/openapi.php
@@ -47,6 +47,8 @@ return [
     'router.openapi.default_response_description' => OpenApiConfiguration::DEFAULT_RESPONSE_DESCRIPTION,
 
     'router.openapi.php_type_schema_resolvers' => [],
+    'router.openapi.use_default_php_type_schema_resolvers' => true,
+
     'router.openapi.operation_enrichers' => [],
     'router.openapi.use_default_operation_enrichers' => true,
 
@@ -71,6 +73,7 @@ return [
         ->constructor(
             openApiConfiguration: get(OpenApiConfiguration::class),
             phpTypeSchemaResolvers: get('router.openapi.php_type_schema_resolvers'),
+            useDefaultPhpTypeSchemaResolvers: get('router.openapi.use_default_php_type_schema_resolvers'),
         ),
 
     OpenApiOperationEnricherManagerInterface::class => create(OpenApiOperationEnricherManager::class)

--- a/resources/definitions/openapi.php
+++ b/resources/definitions/openapi.php
@@ -9,6 +9,8 @@ use Sunrise\Http\Router\OpenApi\OpenApiDocumentManager;
 use Sunrise\Http\Router\OpenApi\OpenApiDocumentManagerInterface;
 use Sunrise\Http\Router\OpenApi\OpenApiOperationEnricherManager;
 use Sunrise\Http\Router\OpenApi\OpenApiOperationEnricherManagerInterface;
+use Sunrise\Http\Router\OpenApi\OpenApiPathBuilder;
+use Sunrise\Http\Router\OpenApi\OpenApiPathBuilderInterface;
 use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaResolverManager;
 use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaResolverManagerInterface;
 use Sunrise\Http\Router\OpenApi\SwaggerConfiguration;
@@ -16,7 +18,6 @@ use Sunrise\Http\Router\RequestHandlerReflectorInterface;
 
 use function DI\create;
 use function DI\get;
-use function DI\string;
 
 return [
     'router.openapi.initial_document' => [
@@ -25,7 +26,7 @@ return [
     ],
 
     'router.openapi.initial_document.info' => [
-        'title' => string('{app.name}@{app.env}'),
+        'title' => get('app.name'),
         'version' => get('app.version'),
     ],
 
@@ -47,6 +48,7 @@ return [
 
     'router.openapi.php_type_schema_resolvers' => [],
     'router.openapi.operation_enrichers' => [],
+    'router.openapi.use_default_operation_enrichers' => true,
 
     'router.swagger.template_filename' => SwaggerConfiguration::DEFAULT_TEMPLATE_FILENAME,
     'router.swagger.css_urls' => SwaggerConfiguration::DEFAULT_CSS_URLS,
@@ -76,7 +78,10 @@ return [
             openApiConfiguration: get(OpenApiConfiguration::class),
             openApiPhpTypeSchemaResolverManager: get(OpenApiPhpTypeSchemaResolverManagerInterface::class),
             operationEnrichers: get('router.openapi.operation_enrichers'),
+            useDefaultOperationEnrichers: get('router.openapi.use_default_operation_enrichers'),
         ),
+
+    OpenApiPathBuilderInterface::class => create(OpenApiPathBuilder::class),
 
     OpenApiDocumentManagerInterface::class => create(OpenApiDocumentManager::class)
         ->constructor(
@@ -85,6 +90,7 @@ return [
             openApiOperationEnricherManager: get(OpenApiOperationEnricherManagerInterface::class),
             requestHandlerReflector: get(RequestHandlerReflectorInterface::class),
             codecManager: get(CodecManagerInterface::class),
+            openApiPathBuilder: get(OpenApiPathBuilderInterface::class),
         ),
 
     SwaggerConfiguration::class => create()

--- a/src/MediaType.php
+++ b/src/MediaType.php
@@ -25,6 +25,14 @@ final class MediaType implements MediaTypeInterface
     ) {
     }
 
+    /**
+     * @since 3.3
+     */
+    public static function create(string $identifier): self
+    {
+        return new self($identifier);
+    }
+
     public function getIdentifier(): string
     {
         return $this->identifier;

--- a/src/Middleware/StringTrimmingMiddleware.php
+++ b/src/Middleware/StringTrimmingMiddleware.php
@@ -41,6 +41,7 @@ final class StringTrimmingMiddleware implements MiddlewareInterface
      */
     public function __construct(?Closure $trimmer = null)
     {
+        /** @psalm-suppress MixedPropertyTypeCoercion */
         $this->trimmer = $trimmer ?? (function_exists('mb_trim') ? mb_trim(...) : trim(...));
     }
 

--- a/src/MiddlewareResolver.php
+++ b/src/MiddlewareResolver.php
@@ -61,10 +61,9 @@ final class MiddlewareResolver implements MiddlewareResolverInterface
 
         // https://github.com/php/php-src/blob/3ed526441400060aa4e618b91b3352371fcd02a8/Zend/zend_API.c#L3884-L3932
         if (is_array($reference) && is_callable($reference, true)) {
-            // @phpstan-ignore-next-line
             /** @var array{0: class-string|object, 1: string} $reference */
 
-            if (is_string($reference[0])) {
+            if (is_string($reference[0])) { // @phpstan-ignore-line varTag.nativeType
                 $reference[0] = $this->classResolver->resolveClass($reference[0]);
             }
 

--- a/src/MiddlewareResolver.php
+++ b/src/MiddlewareResolver.php
@@ -61,6 +61,7 @@ final class MiddlewareResolver implements MiddlewareResolverInterface
 
         // https://github.com/php/php-src/blob/3ed526441400060aa4e618b91b3352371fcd02a8/Zend/zend_API.c#L3884-L3932
         if (is_array($reference) && is_callable($reference, true)) {
+            // @phpstan-ignore-next-line
             /** @var array{0: class-string|object, 1: string} $reference */
 
             if (is_string($reference[0])) {

--- a/src/OpenApi/Annotation/IgnorePropertyInterface.php
+++ b/src/OpenApi/Annotation/IgnorePropertyInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * It's free open-source software released under the MIT License.
+ *
+ * @author Anatoly Nekhay <afenric@gmail.com>
+ * @copyright Copyright (c) 2018, Anatoly Nekhay
+ * @license https://github.com/sunrise-php/http-router/blob/master/LICENSE
+ * @link https://github.com/sunrise-php/http-router
+ */
+
+declare(strict_types=1);
+
+namespace Sunrise\Http\Router\OpenApi\Annotation;
+
+/**
+ * @since 3.3.0
+ */
+interface IgnorePropertyInterface
+{
+}

--- a/src/OpenApi/Annotation/Operation.php
+++ b/src/OpenApi/Annotation/Operation.php
@@ -19,7 +19,7 @@ use Attribute;
  * @since 3.0.0
  */
 #[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
-class Operation
+class Operation implements OperationInterface
 {
     /**
      * @param array<array-key, mixed> $value
@@ -27,5 +27,13 @@ class Operation
     public function __construct(
         public readonly array $value,
     ) {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getOperation(): array
+    {
+        return $this->value;
     }
 }

--- a/src/OpenApi/Annotation/OperationInterface.php
+++ b/src/OpenApi/Annotation/OperationInterface.php
@@ -13,21 +13,13 @@ declare(strict_types=1);
 
 namespace Sunrise\Http\Router\OpenApi\Annotation;
 
-use Attribute;
-
 /**
- * @since 3.2.0
+ * @since 3.3.0
  */
-#[Attribute(Attribute::TARGET_CLASS)]
-class SchemaName implements SchemaNameInterface
+interface OperationInterface
 {
-    public function __construct(
-        public readonly string $value,
-    ) {
-    }
-
-    public function getSchemaName(): string
-    {
-        return $this->value;
-    }
+    /**
+     * @return array<array-key, mixed>
+     */
+    public function getOperation(): array;
 }

--- a/src/OpenApi/Annotation/PropertyNameInterface.php
+++ b/src/OpenApi/Annotation/PropertyNameInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * It's free open-source software released under the MIT License.
+ *
+ * @author Anatoly Nekhay <afenric@gmail.com>
+ * @copyright Copyright (c) 2018, Anatoly Nekhay
+ * @license https://github.com/sunrise-php/http-router/blob/master/LICENSE
+ * @link https://github.com/sunrise-php/http-router
+ */
+
+declare(strict_types=1);
+
+namespace Sunrise\Http\Router\OpenApi\Annotation;
+
+/**
+ * @since 3.3.0
+ */
+interface PropertyNameInterface
+{
+    public function getPropertyName(): string;
+}

--- a/src/OpenApi/Annotation/SchemaName.php
+++ b/src/OpenApi/Annotation/SchemaName.php
@@ -19,7 +19,7 @@ use Attribute;
  * @since 3.2.0
  */
 #[Attribute(Attribute::TARGET_CLASS)]
-final class SchemaName
+class SchemaName
 {
     public function __construct(
         public readonly string $value,

--- a/src/OpenApi/Annotation/SchemaNameInterface.php
+++ b/src/OpenApi/Annotation/SchemaNameInterface.php
@@ -13,21 +13,10 @@ declare(strict_types=1);
 
 namespace Sunrise\Http\Router\OpenApi\Annotation;
 
-use Attribute;
-
 /**
- * @since 3.2.0
+ * @since 3.3.0
  */
-#[Attribute(Attribute::TARGET_CLASS)]
-class SchemaName implements SchemaNameInterface
+interface SchemaNameInterface
 {
-    public function __construct(
-        public readonly string $value,
-    ) {
-    }
-
-    public function getSchemaName(): string
-    {
-        return $this->value;
-    }
+    public function getSchemaName(): string;
 }

--- a/src/OpenApi/Annotation/TimestampFormatInterface.php
+++ b/src/OpenApi/Annotation/TimestampFormatInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * It's free open-source software released under the MIT License.
+ *
+ * @author Anatoly Nekhay <afenric@gmail.com>
+ * @copyright Copyright (c) 2018, Anatoly Nekhay
+ * @license https://github.com/sunrise-php/http-router/blob/master/LICENSE
+ * @link https://github.com/sunrise-php/http-router
+ */
+
+declare(strict_types=1);
+
+namespace Sunrise\Http\Router\OpenApi\Annotation;
+
+/**
+ * @since 3.3.0
+ */
+interface TimestampFormatInterface
+{
+    public function getTimestampFormat(): string;
+}

--- a/src/OpenApi/OpenApiDocumentManager.php
+++ b/src/OpenApi/OpenApiDocumentManager.php
@@ -139,8 +139,12 @@ final class OpenApiDocumentManager implements OpenApiDocumentManagerInterface
         }
 
         array_walk_recursive($operation, function (mixed &$value) use ($requestHandler): void {
-            if ($value instanceof Type) {
-                $value = $this->openApiPhpTypeSchemaResolverManager->resolvePhpTypeSchema($value, $requestHandler);
+            if ($value instanceof TypeInterface) {
+                $value = $this->openApiPhpTypeSchemaResolverManager
+                    ->resolvePhpTypeSchema($value, $requestHandler);
+            } elseif (\is_string($value) && \str_contains($value, '\\') && \class_exists($value)) {
+                $value = $this->openApiPhpTypeSchemaResolverManager
+                    ->resolvePhpTypeSchema(new Type($value), $requestHandler);
             }
         });
 

--- a/src/OpenApi/OpenApiDocumentManager.php
+++ b/src/OpenApi/OpenApiDocumentManager.php
@@ -17,7 +17,7 @@ use ReflectionAttribute;
 use RuntimeException;
 use Sunrise\Coder\CodecManagerInterface;
 use Sunrise\Http\Router\Helper\ReflectorHelper;
-use Sunrise\Http\Router\OpenApi\Annotation\Operation;
+use Sunrise\Http\Router\OpenApi\Annotation\OperationInterface;
 use Sunrise\Http\Router\RequestHandlerReflectorInterface;
 use Sunrise\Http\Router\RouteInterface;
 use Throwable;
@@ -131,9 +131,10 @@ final class OpenApiDocumentManager implements OpenApiDocumentManagerInterface
         $requestHandler = $this->requestHandlerReflector->reflectRequestHandler($route->getRequestHandler());
 
         foreach (ReflectorHelper::getAncestry($requestHandler) as $member) {
-            /** @var ReflectionAttribute<Operation> $annotation */
-            foreach ($member->getAttributes(Operation::class, ReflectionAttribute::IS_INSTANCEOF) as $annotation) {
-                $operation = array_replace_recursive($operation, $annotation->newInstance()->value);
+            /** @var list<ReflectionAttribute<OperationInterface>> $annotations */
+            $annotations = $member->getAttributes(OperationInterface::class, ReflectionAttribute::IS_INSTANCEOF);
+            foreach ($annotations as $annotation) {
+                $operation = array_replace_recursive($operation, $annotation->newInstance()->getOperation());
             }
         }
 

--- a/src/OpenApi/OpenApiDocumentManager.php
+++ b/src/OpenApi/OpenApiDocumentManager.php
@@ -17,7 +17,6 @@ use ReflectionAttribute;
 use RuntimeException;
 use Sunrise\Coder\CodecManagerInterface;
 use Sunrise\Http\Router\Helper\ReflectorHelper;
-use Sunrise\Http\Router\Helper\RouteSimplifier;
 use Sunrise\Http\Router\OpenApi\Annotation\Operation;
 use Sunrise\Http\Router\RequestHandlerReflectorInterface;
 use Sunrise\Http\Router\RouteInterface;
@@ -45,6 +44,7 @@ final class OpenApiDocumentManager implements OpenApiDocumentManagerInterface
         private readonly OpenApiOperationEnricherManagerInterface $openApiOperationEnricherManager,
         private readonly RequestHandlerReflectorInterface $requestHandlerReflector,
         private readonly CodecManagerInterface $codecManager,
+        private readonly OpenApiPathBuilderInterface $openApiPathBuilder = new OpenApiPathBuilder(),
     ) {
     }
 
@@ -154,7 +154,7 @@ final class OpenApiDocumentManager implements OpenApiDocumentManagerInterface
             $operation['deprecated'] = true;
         }
 
-        $path = RouteSimplifier::simplifyRoute($route->getPath());
+        $path = $this->openApiPathBuilder->buildPath($route);
         foreach ($route->getMethods() as $method) {
             $document['paths'][$path][strtolower($method)] = $operation;
         }

--- a/src/OpenApi/OpenApiOperationEnricherManager.php
+++ b/src/OpenApi/OpenApiOperationEnricherManager.php
@@ -45,9 +45,13 @@ final class OpenApiOperationEnricherManager implements OpenApiOperationEnricherM
         private readonly OpenApiConfiguration $openApiConfiguration,
         private readonly OpenApiPhpTypeSchemaResolverManagerInterface $openApiPhpTypeSchemaResolverManager,
         array $operationEnrichers = [],
+        bool $useDefaultOperationEnrichers = true,
     ) {
-        $this->setOperationEnrichers(self::getDefaultOperationEnrichers());
         $this->setOperationEnrichers($operationEnrichers);
+
+        if ($useDefaultOperationEnrichers) {
+            $this->setOperationEnrichers(self::getDefaultOperationEnrichers());
+        }
     }
 
     /**

--- a/src/OpenApi/OpenApiPathBuilder.php
+++ b/src/OpenApi/OpenApiPathBuilder.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * It's free open-source software released under the MIT License.
+ *
+ * @author Anatoly Nekhay <afenric@gmail.com>
+ * @copyright Copyright (c) 2018, Anatoly Nekhay
+ * @license https://github.com/sunrise-php/http-router/blob/master/LICENSE
+ * @link https://github.com/sunrise-php/http-router
+ */
+
+declare(strict_types=1);
+
+namespace Sunrise\Http\Router\OpenApi;
+
+use Sunrise\Http\Router\Helper\RouteSimplifier;
+use Sunrise\Http\Router\RouteInterface;
+
+/**
+ * @since 3.3.0
+ */
+final class OpenApiPathBuilder implements OpenApiPathBuilderInterface
+{
+    public function buildPath(RouteInterface $route): string
+    {
+        return RouteSimplifier::simplifyRoute($route->getPath());
+    }
+}

--- a/src/OpenApi/OpenApiPathBuilderInterface.php
+++ b/src/OpenApi/OpenApiPathBuilderInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * It's free open-source software released under the MIT License.
+ *
+ * @author Anatoly Nekhay <afenric@gmail.com>
+ * @copyright Copyright (c) 2018, Anatoly Nekhay
+ * @license https://github.com/sunrise-php/http-router/blob/master/LICENSE
+ * @link https://github.com/sunrise-php/http-router
+ */
+
+declare(strict_types=1);
+
+namespace Sunrise\Http\Router\OpenApi;
+
+use Sunrise\Http\Router\RouteInterface;
+
+/**
+ * @since 3.3.0
+ */
+interface OpenApiPathBuilderInterface
+{
+    public function buildPath(RouteInterface $route): string;
+}

--- a/src/OpenApi/OpenApiPhpTypeSchemaResolverInterface.php
+++ b/src/OpenApi/OpenApiPhpTypeSchemaResolverInterface.php
@@ -21,14 +21,14 @@ use Sunrise\Http\Router\OpenApi\Exception\UnsupportedPhpTypeException;
  */
 interface OpenApiPhpTypeSchemaResolverInterface
 {
-    public function supportsPhpType(Type $phpType, Reflector $phpTypeHolder): bool;
+    public function supportsPhpType(TypeInterface $phpType, Reflector $phpTypeHolder): bool;
 
     /**
      * @return array<array-key, mixed>
      *
      * @throws UnsupportedPhpTypeException Must be thrown if the type isn't supported.
      */
-    public function resolvePhpTypeSchema(Type $phpType, Reflector $phpTypeHolder): array;
+    public function resolvePhpTypeSchema(TypeInterface $phpType, Reflector $phpTypeHolder): array;
 
     public function getWeight(): int;
 }

--- a/src/OpenApi/OpenApiPhpTypeSchemaResolverManager.php
+++ b/src/OpenApi/OpenApiPhpTypeSchemaResolverManager.php
@@ -54,9 +54,13 @@ final class OpenApiPhpTypeSchemaResolverManager implements OpenApiPhpTypeSchemaR
     public function __construct(
         private readonly OpenApiConfiguration $openApiConfiguration,
         array $phpTypeSchemaResolvers = [],
+        bool $useDefaultPhpTypeSchemaResolvers = true,
     ) {
-        $this->setPhpTypeSchemaResolvers(self::getDefaultPhpTypeSchemaResolvers());
         $this->setPhpTypeSchemaResolvers($phpTypeSchemaResolvers);
+
+        if ($useDefaultPhpTypeSchemaResolvers) {
+            $this->setPhpTypeSchemaResolvers(self::getDefaultPhpTypeSchemaResolvers());
+        }
     }
 
     /**

--- a/src/OpenApi/OpenApiPhpTypeSchemaResolverManager.php
+++ b/src/OpenApi/OpenApiPhpTypeSchemaResolverManager.php
@@ -66,7 +66,7 @@ final class OpenApiPhpTypeSchemaResolverManager implements OpenApiPhpTypeSchemaR
     /**
      * @inheritDoc
      */
-    public function resolvePhpTypeSchema(Type $phpType, Reflector $phpTypeHolder): array
+    public function resolvePhpTypeSchema(TypeInterface $phpType, Reflector $phpTypeHolder): array
     {
         $this->isPhpTypeSchemaResolversSorted or $this->sortPhpTypeSchemaResolvers();
 
@@ -128,7 +128,7 @@ final class OpenApiPhpTypeSchemaResolverManager implements OpenApiPhpTypeSchemaR
     }
 
     private function findPhpTypeSchemaResolver(
-        Type $phpType,
+        TypeInterface $phpType,
         Reflector $phpTypeHolder,
     ): ?OpenApiPhpTypeSchemaResolverInterface {
         foreach ($this->phpTypeSchemaResolvers as $phpTypeSchemaResolver) {
@@ -163,9 +163,9 @@ final class OpenApiPhpTypeSchemaResolverManager implements OpenApiPhpTypeSchemaR
      *
      * @return array<array-key, mixed>
      */
-    private static function completePhpTypeSchema(Type $phpType, array $phpTypeSchema): array
+    private static function completePhpTypeSchema(TypeInterface $phpType, array $phpTypeSchema): array
     {
-        if ($phpType->allowsNull) {
+        if ($phpType->allowsNull()) {
             $phpTypeSchema = [
                 'anyOf' => [
                     $phpTypeSchema,

--- a/src/OpenApi/OpenApiPhpTypeSchemaResolverManagerInterface.php
+++ b/src/OpenApi/OpenApiPhpTypeSchemaResolverManagerInterface.php
@@ -23,7 +23,7 @@ interface OpenApiPhpTypeSchemaResolverManagerInterface
     /**
      * @return array<array-key, mixed>
      */
-    public function resolvePhpTypeSchema(Type $phpType, Reflector $phpTypeHolder): array;
+    public function resolvePhpTypeSchema(TypeInterface $phpType, Reflector $phpTypeHolder): array;
 
     /**
      * @param array<array-key, mixed> $document

--- a/src/OpenApi/OperationEnricher/EmptyResponseOperationEnricher.php
+++ b/src/OpenApi/OperationEnricher/EmptyResponseOperationEnricher.php
@@ -49,8 +49,8 @@ final class EmptyResponseOperationEnricher extends AbstractResponseOperationEnri
             return;
         }
 
-        $responseBodyType = TypeFactory::fromPhpTypeReflection($requestHandler->getReturnType());
-        if (!$responseBodyType->is(Type::PHP_TYPE_NAME_VOID)) {
+        $responseType = TypeFactory::fromPhpTypeReflection($requestHandler->getReturnType());
+        if ($responseType->getName() !== Type::PHP_TYPE_NAME_VOID) {
             return;
         }
 

--- a/src/OpenApi/OperationEnricher/RequestBodyOperationEnricher.php
+++ b/src/OpenApi/OperationEnricher/RequestBodyOperationEnricher.php
@@ -55,7 +55,7 @@ final class RequestBodyOperationEnricher implements
             $requestBodyType = TypeFactory::fromPhpTypeReflection($requestHandlerParameter->getType());
             if (
                 $requestHandlerParameter->getAttributes(RequestBody::class) !== [] ||
-                $requestBodyType->is(StreamInterface::class)
+                $requestBodyType->getName() === StreamInterface::class
             ) {
                 $requestBodySchema = $this->openApiPhpTypeSchemaResolverManager
                     ->resolvePhpTypeSchema($requestBodyType, $requestHandlerParameter);

--- a/src/OpenApi/PhpTypeSchemaResolver/ArrayAccessPhpTypeSchemaResolver.php
+++ b/src/OpenApi/PhpTypeSchemaResolver/ArrayAccessPhpTypeSchemaResolver.php
@@ -26,6 +26,7 @@ use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaResolverManagerAwareInterfac
 use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaResolverManagerInterface;
 use Sunrise\Http\Router\OpenApi\Type;
 use Sunrise\Http\Router\OpenApi\TypeFactory;
+use Sunrise\Http\Router\OpenApi\TypeInterface;
 use Sunrise\Hydrator\Annotation\Subtype;
 
 use function end;
@@ -46,9 +47,9 @@ final class ArrayAccessPhpTypeSchemaResolver implements
         $this->openApiPhpTypeSchemaResolverManager = $openApiPhpTypeSchemaResolverManager;
     }
 
-    public function supportsPhpType(Type $phpType, Reflector $phpTypeHolder): bool
+    public function supportsPhpType(TypeInterface $phpType, Reflector $phpTypeHolder): bool
     {
-        return is_subclass_of($phpType->name, ArrayAccess::class);
+        return is_subclass_of($phpType->getName(), ArrayAccess::class);
     }
 
     /**
@@ -56,14 +57,14 @@ final class ArrayAccessPhpTypeSchemaResolver implements
      *
      * @throws ReflectionException
      */
-    public function resolvePhpTypeSchema(Type $phpType, Reflector $phpTypeHolder): array
+    public function resolvePhpTypeSchema(TypeInterface $phpType, Reflector $phpTypeHolder): array
     {
         $this->supportsPhpType($phpType, $phpTypeHolder) or throw new UnsupportedPhpTypeException();
 
         /** @var class-string<ArrayAccess<array-key, mixed>> $phpTypeName */
-        $phpTypeName = $phpType->name;
+        $phpTypeName = $phpType->getName();
 
-        $arrayPhpType = new Type(Type::PHP_TYPE_NAME_ARRAY, $phpType->allowsNull);
+        $arrayPhpType = new Type(Type::PHP_TYPE_NAME_ARRAY, $phpType->allowsNull());
         $phpTypeSchema = $this->openApiPhpTypeSchemaResolverManager
             ->resolvePhpTypeSchema($arrayPhpType, $phpTypeHolder);
 
@@ -92,7 +93,7 @@ final class ArrayAccessPhpTypeSchemaResolver implements
      *
      * @throws ReflectionException
      */
-    private static function getCollectionElementPhpType(string $className): Type
+    private static function getCollectionElementPhpType(string $className): TypeInterface
     {
         $constructorParameters = (new ReflectionClass($className))->getConstructor()?->getParameters() ?? [];
 

--- a/src/OpenApi/PhpTypeSchemaResolver/ArrayAccessPhpTypeSchemaResolver.php
+++ b/src/OpenApi/PhpTypeSchemaResolver/ArrayAccessPhpTypeSchemaResolver.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sunrise\Http\Router\OpenApi\PhpTypeSchemaResolver;
 
 use ArrayAccess;
+use ReflectionAttribute;
 use ReflectionClass;
 use ReflectionException;
 use ReflectionParameter;
@@ -69,7 +70,7 @@ final class ArrayAccessPhpTypeSchemaResolver implements
         if (
             ! $phpTypeHolder instanceof ReflectionParameter
             && ! $phpTypeHolder instanceof ReflectionProperty
-            || $phpTypeHolder->getAttributes(Subtype::class, \ReflectionAttribute::IS_INSTANCEOF) === []
+            || $phpTypeHolder->getAttributes(Subtype::class, ReflectionAttribute::IS_INSTANCEOF) === []
         ) {
             $collectionElementPhpType = self::getCollectionElementPhpType($phpTypeName);
             $collectionElementPhpTypeSchema = $this->openApiPhpTypeSchemaResolverManager

--- a/src/OpenApi/PhpTypeSchemaResolver/ArrayAccessPhpTypeSchemaResolver.php
+++ b/src/OpenApi/PhpTypeSchemaResolver/ArrayAccessPhpTypeSchemaResolver.php
@@ -69,7 +69,7 @@ final class ArrayAccessPhpTypeSchemaResolver implements
         if (
             ! $phpTypeHolder instanceof ReflectionParameter
             && ! $phpTypeHolder instanceof ReflectionProperty
-            || $phpTypeHolder->getAttributes(Subtype::class) === []
+            || $phpTypeHolder->getAttributes(Subtype::class, \ReflectionAttribute::IS_INSTANCEOF) === []
         ) {
             $collectionElementPhpType = self::getCollectionElementPhpType($phpTypeName);
             $collectionElementPhpTypeSchema = $this->openApiPhpTypeSchemaResolverManager

--- a/src/OpenApi/PhpTypeSchemaResolver/ArrayPhpTypeSchemaResolver.php
+++ b/src/OpenApi/PhpTypeSchemaResolver/ArrayPhpTypeSchemaResolver.php
@@ -84,13 +84,11 @@ final class ArrayPhpTypeSchemaResolver implements
             }
         }
 
-        if ($phpTypeHolder instanceof ReflectionProperty) {
-            if (!isset($phpTypeSchema['items'])) {
-                $itemPhpType = $this->getItemTypeFromDocBlock($phpTypeHolder);
-                if ($itemPhpType !== null) {
-                    $phpTypeSchema['items'] = $this->openApiPhpTypeSchemaResolverManager
-                        ->resolvePhpTypeSchema($itemPhpType, $phpTypeHolder);
-                }
+        if (!isset($phpTypeSchema['items'])) {
+            $itemPhpType = $this->getItemTypeFromDocBlock($phpTypeHolder);
+            if ($itemPhpType !== null) {
+                $phpTypeSchema['items'] = $this->openApiPhpTypeSchemaResolverManager
+                    ->resolvePhpTypeSchema($itemPhpType, $phpTypeHolder);
             }
         }
 
@@ -102,8 +100,12 @@ final class ArrayPhpTypeSchemaResolver implements
         return 0;
     }
 
-    private function getItemTypeFromDocBlock(ReflectionProperty $phpTypeHolder): ?TypeInterface
+    private function getItemTypeFromDocBlock(Reflector $phpTypeHolder): ?TypeInterface
     {
+        if (! $phpTypeHolder instanceof ReflectionProperty) {
+            return null;
+        }
+
         $docComment = $phpTypeHolder->getDocComment();
         if ($docComment === false) {
             return null;

--- a/src/OpenApi/PhpTypeSchemaResolver/ArrayPhpTypeSchemaResolver.php
+++ b/src/OpenApi/PhpTypeSchemaResolver/ArrayPhpTypeSchemaResolver.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sunrise\Http\Router\OpenApi\PhpTypeSchemaResolver;
 
+use phpDocumentor\Reflection as PhpDoc;
 use ReflectionAttribute;
 use ReflectionParameter;
 use ReflectionProperty;
@@ -33,6 +34,14 @@ final class ArrayPhpTypeSchemaResolver implements
     OpenApiPhpTypeSchemaResolverManagerAwareInterface
 {
     private readonly OpenApiPhpTypeSchemaResolverManagerInterface $openApiPhpTypeSchemaResolverManager;
+    private readonly PhpDoc\DocBlockFactoryInterface $docBlockFactory;
+    private readonly PhpDoc\Types\ContextFactory $docBlockContextFactory;
+
+    public function __construct()
+    {
+        $this->docBlockFactory = PhpDoc\DocBlockFactory::createInstance();
+        $this->docBlockContextFactory = new PhpDoc\Types\ContextFactory();
+    }
 
     public function setOpenApiPhpTypeSchemaResolverManager(
         OpenApiPhpTypeSchemaResolverManagerInterface $openApiPhpTypeSchemaResolverManager,
@@ -65,13 +74,22 @@ final class ArrayPhpTypeSchemaResolver implements
             if (isset($annotations[0])) {
                 $annotation = $annotations[0]->newInstance();
 
-                $arrayElementPhpType = new Type($annotation->name, $annotation->allowsNull);
-                $arrayElementPhpTypeSchema = $this->openApiPhpTypeSchemaResolverManager
-                    ->resolvePhpTypeSchema($arrayElementPhpType, $phpTypeHolder);
+                $itemPhpType = new Type($annotation->name, $annotation->allowsNull);
+                $phpTypeSchema['items'] = $this->openApiPhpTypeSchemaResolverManager
+                    ->resolvePhpTypeSchema($itemPhpType, $phpTypeHolder);
 
-                $phpTypeSchema['items'] = $arrayElementPhpTypeSchema;
                 if ($annotation->limit !== null) {
                     $phpTypeSchema['maxItems'] = $annotation->limit;
+                }
+            }
+        }
+
+        if ($phpTypeHolder instanceof ReflectionProperty) {
+            if (!isset($phpTypeSchema['items'])) {
+                $itemPhpType = $this->getItemTypeFromDocBlock($phpTypeHolder);
+                if ($itemPhpType !== null) {
+                    $phpTypeSchema['items'] = $this->openApiPhpTypeSchemaResolverManager
+                        ->resolvePhpTypeSchema($itemPhpType, $phpTypeHolder);
                 }
             }
         }
@@ -82,5 +100,79 @@ final class ArrayPhpTypeSchemaResolver implements
     public function getWeight(): int
     {
         return 0;
+    }
+
+    private function getItemTypeFromDocBlock(ReflectionProperty $phpTypeHolder): ?TypeInterface
+    {
+        $docComment = $phpTypeHolder->getDocComment();
+        if ($docComment === false) {
+            return null;
+        }
+
+        $docBlock = $this->docBlockFactory->create(
+            $docComment,
+            $this->docBlockContextFactory->createFromReflector($phpTypeHolder),
+        );
+
+        $varTags = $docBlock->getTagsByName('var');
+        if ($varTags === [] || ! $varTags[0] instanceof PhpDoc\DocBlock\Tags\Var_) {
+            return null;
+        }
+
+        $varType = $varTags[0]->getType();
+        if ($varType === null) {
+            return null;
+        }
+
+        $varType = self::unwrapNullablePhpDocType($varType);
+        if (! $varType instanceof PhpDoc\Types\AbstractList) {
+            return null;
+        }
+
+        $itemType = $varType->getValueType();
+
+        return new Type(
+            name: \ltrim((string) self::unwrapNullablePhpDocType($itemType), '\\'),
+            allowsNull: self::isNullablePhpDocType($itemType),
+        );
+    }
+
+    private static function unwrapNullablePhpDocType(PhpDoc\Type $phpDocType): PhpDoc\Type
+    {
+        if ($phpDocType instanceof PhpDoc\Types\Nullable) {
+            return $phpDocType->getActualType();
+        }
+
+        if ($phpDocType instanceof PhpDoc\Types\Compound) {
+            $types = [];
+            foreach ($phpDocType as $type) {
+                if (! $type instanceof PhpDoc\Types\Null_) {
+                    $types[] = $type;
+                }
+            }
+
+            if (\count($types) === 1) {
+                return $types[0];
+            }
+        }
+
+        return $phpDocType;
+    }
+
+    private static function isNullablePhpDocType(PhpDoc\Type $phpDocType): bool
+    {
+        if ($phpDocType instanceof PhpDoc\Types\Nullable) {
+            return true;
+        }
+
+        if ($phpDocType instanceof PhpDoc\Types\Compound) {
+            foreach ($phpDocType as $type) {
+                if ($type instanceof PhpDoc\Types\Null_) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/src/OpenApi/PhpTypeSchemaResolver/ArrayPhpTypeSchemaResolver.php
+++ b/src/OpenApi/PhpTypeSchemaResolver/ArrayPhpTypeSchemaResolver.php
@@ -22,6 +22,7 @@ use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaResolverInterface;
 use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaResolverManagerAwareInterface;
 use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaResolverManagerInterface;
 use Sunrise\Http\Router\OpenApi\Type;
+use Sunrise\Http\Router\OpenApi\TypeInterface;
 use Sunrise\Hydrator\Annotation\Subtype;
 
 /**
@@ -39,15 +40,15 @@ final class ArrayPhpTypeSchemaResolver implements
         $this->openApiPhpTypeSchemaResolverManager = $openApiPhpTypeSchemaResolverManager;
     }
 
-    public function supportsPhpType(Type $phpType, Reflector $phpTypeHolder): bool
+    public function supportsPhpType(TypeInterface $phpType, Reflector $phpTypeHolder): bool
     {
-        return $phpType->name == Type::PHP_TYPE_NAME_ARRAY;
+        return $phpType->getName() == Type::PHP_TYPE_NAME_ARRAY;
     }
 
     /**
      * @inheritDoc
      */
-    public function resolvePhpTypeSchema(Type $phpType, Reflector $phpTypeHolder): array
+    public function resolvePhpTypeSchema(TypeInterface $phpType, Reflector $phpTypeHolder): array
     {
         $this->supportsPhpType($phpType, $phpTypeHolder) or throw new UnsupportedPhpTypeException();
 

--- a/src/OpenApi/PhpTypeSchemaResolver/ArrayPhpTypeSchemaResolver.php
+++ b/src/OpenApi/PhpTypeSchemaResolver/ArrayPhpTypeSchemaResolver.php
@@ -60,7 +60,7 @@ final class ArrayPhpTypeSchemaResolver implements
             $phpTypeHolder instanceof ReflectionProperty
         ) {
             /** @var list<ReflectionAttribute<Subtype>> $annotations */
-            $annotations = $phpTypeHolder->getAttributes(Subtype::class);
+            $annotations = $phpTypeHolder->getAttributes(Subtype::class, ReflectionAttribute::IS_INSTANCEOF);
             if (isset($annotations[0])) {
                 $annotation = $annotations[0]->newInstance();
 

--- a/src/OpenApi/PhpTypeSchemaResolver/BackedEnumPhpTypeSchemaResolver.php
+++ b/src/OpenApi/PhpTypeSchemaResolver/BackedEnumPhpTypeSchemaResolver.php
@@ -19,7 +19,7 @@ use ReflectionClass;
 use ReflectionEnum;
 use ReflectionException;
 use Reflector;
-use Sunrise\Http\Router\OpenApi\Annotation\SchemaName;
+use Sunrise\Http\Router\OpenApi\Annotation\SchemaNameInterface;
 use Sunrise\Http\Router\OpenApi\Exception\UnsupportedPhpTypeException;
 use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaNameResolverInterface;
 use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaResolverInterface;
@@ -85,11 +85,10 @@ final class BackedEnumPhpTypeSchemaResolver implements
         $className = $phpType->name;
         $classReflection = new ReflectionClass($className);
 
-        /** @var list<ReflectionAttribute<SchemaName>> $annotations */
-        $annotations = $classReflection->getAttributes(SchemaName::class, ReflectionAttribute::IS_INSTANCEOF);
+        /** @var list<ReflectionAttribute<SchemaNameInterface>> $annotations */
+        $annotations = $classReflection->getAttributes(SchemaNameInterface::class, ReflectionAttribute::IS_INSTANCEOF);
         if (isset($annotations[0])) {
-            $annotation = $annotations[0]->newInstance();
-            return $annotation->value;
+            return $annotations[0]->newInstance()->getSchemaName();
         }
 
         return $classReflection->getShortName();

--- a/src/OpenApi/PhpTypeSchemaResolver/BackedEnumPhpTypeSchemaResolver.php
+++ b/src/OpenApi/PhpTypeSchemaResolver/BackedEnumPhpTypeSchemaResolver.php
@@ -86,7 +86,7 @@ final class BackedEnumPhpTypeSchemaResolver implements
         $classReflection = new ReflectionClass($className);
 
         /** @var list<ReflectionAttribute<SchemaName>> $annotations */
-        $annotations = $classReflection->getAttributes(SchemaName::class);
+        $annotations = $classReflection->getAttributes(SchemaName::class, ReflectionAttribute::IS_INSTANCEOF);
         if (isset($annotations[0])) {
             $annotation = $annotations[0]->newInstance();
             return $annotation->value;

--- a/src/OpenApi/PhpTypeSchemaResolver/BackedEnumPhpTypeSchemaResolver.php
+++ b/src/OpenApi/PhpTypeSchemaResolver/BackedEnumPhpTypeSchemaResolver.php
@@ -25,8 +25,8 @@ use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaNameResolverInterface;
 use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaResolverInterface;
 use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaResolverManagerAwareInterface;
 use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaResolverManagerInterface;
-use Sunrise\Http\Router\OpenApi\Type;
 use Sunrise\Http\Router\OpenApi\TypeFactory;
+use Sunrise\Http\Router\OpenApi\TypeInterface;
 
 use function is_subclass_of;
 
@@ -46,9 +46,9 @@ final class BackedEnumPhpTypeSchemaResolver implements
         $this->openApiPhpTypeSchemaResolverManager = $openApiPhpTypeSchemaResolverManager;
     }
 
-    public function supportsPhpType(Type $phpType, Reflector $phpTypeHolder): bool
+    public function supportsPhpType(TypeInterface $phpType, Reflector $phpTypeHolder): bool
     {
-        return is_subclass_of($phpType->name, BackedEnum::class);
+        return is_subclass_of($phpType->getName(), BackedEnum::class);
     }
 
     /**
@@ -56,12 +56,12 @@ final class BackedEnumPhpTypeSchemaResolver implements
      *
      * @throws ReflectionException
      */
-    public function resolvePhpTypeSchema(Type $phpType, Reflector $phpTypeHolder): array
+    public function resolvePhpTypeSchema(TypeInterface $phpType, Reflector $phpTypeHolder): array
     {
         $this->supportsPhpType($phpType, $phpTypeHolder) or throw new UnsupportedPhpTypeException();
 
         /** @var class-string<BackedEnum> $phpTypeName */
-        $phpTypeName = $phpType->name;
+        $phpTypeName = $phpType->getName();
 
         $enumPhpType = TypeFactory::fromPhpTypeReflection((new ReflectionEnum($phpTypeName))->getBackingType());
         $phpTypeSchema = $this->openApiPhpTypeSchemaResolverManager->resolvePhpTypeSchema($enumPhpType, $phpTypeHolder);
@@ -79,10 +79,10 @@ final class BackedEnumPhpTypeSchemaResolver implements
         return 0;
     }
 
-    public function resolvePhpTypeSchemaName(Type $phpType, Reflector $phpTypeHolder): string
+    public function resolvePhpTypeSchemaName(TypeInterface $phpType, Reflector $phpTypeHolder): string
     {
         /** @var class-string $className */
-        $className = $phpType->name;
+        $className = $phpType->getName();
         $classReflection = new ReflectionClass($className);
 
         /** @var list<ReflectionAttribute<SchemaNameInterface>> $annotations */

--- a/src/OpenApi/PhpTypeSchemaResolver/BoolPhpTypeSchemaResolver.php
+++ b/src/OpenApi/PhpTypeSchemaResolver/BoolPhpTypeSchemaResolver.php
@@ -17,21 +17,22 @@ use Reflector;
 use Sunrise\Http\Router\OpenApi\Exception\UnsupportedPhpTypeException;
 use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaResolverInterface;
 use Sunrise\Http\Router\OpenApi\Type;
+use Sunrise\Http\Router\OpenApi\TypeInterface;
 
 /**
  * @since 3.0.0
  */
 final class BoolPhpTypeSchemaResolver implements OpenApiPhpTypeSchemaResolverInterface
 {
-    public function supportsPhpType(Type $phpType, Reflector $phpTypeHolder): bool
+    public function supportsPhpType(TypeInterface $phpType, Reflector $phpTypeHolder): bool
     {
-        return $phpType->name === Type::PHP_TYPE_NAME_BOOL;
+        return $phpType->getName() === Type::PHP_TYPE_NAME_BOOL;
     }
 
     /**
      * @inheritDoc
      */
-    public function resolvePhpTypeSchema(Type $phpType, Reflector $phpTypeHolder): array
+    public function resolvePhpTypeSchema(TypeInterface $phpType, Reflector $phpTypeHolder): array
     {
         $this->supportsPhpType($phpType, $phpTypeHolder) or throw new UnsupportedPhpTypeException();
 

--- a/src/OpenApi/PhpTypeSchemaResolver/FloatPhpTypeSchemaResolver.php
+++ b/src/OpenApi/PhpTypeSchemaResolver/FloatPhpTypeSchemaResolver.php
@@ -17,21 +17,22 @@ use Reflector;
 use Sunrise\Http\Router\OpenApi\Exception\UnsupportedPhpTypeException;
 use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaResolverInterface;
 use Sunrise\Http\Router\OpenApi\Type;
+use Sunrise\Http\Router\OpenApi\TypeInterface;
 
 /**
  * @since 3.0.0
  */
 final class FloatPhpTypeSchemaResolver implements OpenApiPhpTypeSchemaResolverInterface
 {
-    public function supportsPhpType(Type $phpType, Reflector $phpTypeHolder): bool
+    public function supportsPhpType(TypeInterface $phpType, Reflector $phpTypeHolder): bool
     {
-        return $phpType->name === Type::PHP_TYPE_NAME_FLOAT;
+        return $phpType->getName() === Type::PHP_TYPE_NAME_FLOAT;
     }
 
     /**
      * @inheritDoc
      */
-    public function resolvePhpTypeSchema(Type $phpType, Reflector $phpTypeHolder): array
+    public function resolvePhpTypeSchema(TypeInterface $phpType, Reflector $phpTypeHolder): array
     {
         $this->supportsPhpType($phpType, $phpTypeHolder) or throw new UnsupportedPhpTypeException();
 

--- a/src/OpenApi/PhpTypeSchemaResolver/IntPhpTypeSchemaResolver.php
+++ b/src/OpenApi/PhpTypeSchemaResolver/IntPhpTypeSchemaResolver.php
@@ -17,6 +17,7 @@ use Reflector;
 use Sunrise\Http\Router\OpenApi\Exception\UnsupportedPhpTypeException;
 use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaResolverInterface;
 use Sunrise\Http\Router\OpenApi\Type;
+use Sunrise\Http\Router\OpenApi\TypeInterface;
 
 use const PHP_INT_SIZE;
 
@@ -25,15 +26,15 @@ use const PHP_INT_SIZE;
  */
 final class IntPhpTypeSchemaResolver implements OpenApiPhpTypeSchemaResolverInterface
 {
-    public function supportsPhpType(Type $phpType, Reflector $phpTypeHolder): bool
+    public function supportsPhpType(TypeInterface $phpType, Reflector $phpTypeHolder): bool
     {
-        return $phpType->name === Type::PHP_TYPE_NAME_INT;
+        return $phpType->getName() === Type::PHP_TYPE_NAME_INT;
     }
 
     /**
      * @inheritDoc
      */
-    public function resolvePhpTypeSchema(Type $phpType, Reflector $phpTypeHolder): array
+    public function resolvePhpTypeSchema(TypeInterface $phpType, Reflector $phpTypeHolder): array
     {
         $this->supportsPhpType($phpType, $phpTypeHolder) or throw new UnsupportedPhpTypeException();
 

--- a/src/OpenApi/PhpTypeSchemaResolver/ObjectPhpTypeSchemaResolver.php
+++ b/src/OpenApi/PhpTypeSchemaResolver/ObjectPhpTypeSchemaResolver.php
@@ -131,7 +131,7 @@ final class ObjectPhpTypeSchemaResolver implements
         $classReflection = new ReflectionClass($className);
 
         /** @var list<ReflectionAttribute<SchemaName>> $annotations */
-        $annotations = $classReflection->getAttributes(SchemaName::class);
+        $annotations = $classReflection->getAttributes(SchemaName::class, ReflectionAttribute::IS_INSTANCEOF);
         if (isset($annotations[0])) {
             $annotation = $annotations[0]->newInstance();
             return $annotation->value;

--- a/src/OpenApi/PhpTypeSchemaResolver/ObjectPhpTypeSchemaResolver.php
+++ b/src/OpenApi/PhpTypeSchemaResolver/ObjectPhpTypeSchemaResolver.php
@@ -27,7 +27,6 @@ use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaNameResolverInterface;
 use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaResolverInterface;
 use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaResolverManagerAwareInterface;
 use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaResolverManagerInterface;
-use Sunrise\Http\Router\OpenApi\Type;
 use Sunrise\Http\Router\OpenApi\TypeFactory;
 use Sunrise\Http\Router\OpenApi\TypeInterface;
 use Sunrise\Hydrator\Annotation\Alias;

--- a/src/OpenApi/PhpTypeSchemaResolver/ObjectPhpTypeSchemaResolver.php
+++ b/src/OpenApi/PhpTypeSchemaResolver/ObjectPhpTypeSchemaResolver.php
@@ -29,6 +29,7 @@ use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaResolverManagerAwareInterfac
 use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaResolverManagerInterface;
 use Sunrise\Http\Router\OpenApi\Type;
 use Sunrise\Http\Router\OpenApi\TypeFactory;
+use Sunrise\Http\Router\OpenApi\TypeInterface;
 use Sunrise\Hydrator\Annotation\Alias;
 use Sunrise\Hydrator\Annotation\DefaultValue;
 use Sunrise\Hydrator\Annotation\Ignore;
@@ -56,9 +57,9 @@ final class ObjectPhpTypeSchemaResolver implements
     /**
      * @see ObjectTypeConverter
      */
-    public function supportsPhpType(Type $phpType, Reflector $phpTypeHolder): bool
+    public function supportsPhpType(TypeInterface $phpType, Reflector $phpTypeHolder): bool
     {
-        $className = $phpType->name;
+        $className = $phpType->getName();
         if (!class_exists($className)) {
             return false;
         }
@@ -76,12 +77,12 @@ final class ObjectPhpTypeSchemaResolver implements
      *
      * @throws ReflectionException
      */
-    public function resolvePhpTypeSchema(Type $phpType, Reflector $phpTypeHolder): array
+    public function resolvePhpTypeSchema(TypeInterface $phpType, Reflector $phpTypeHolder): array
     {
         $this->supportsPhpType($phpType, $phpTypeHolder) or throw new UnsupportedPhpTypeException();
 
         /** @var class-string $phpTypeName */
-        $phpTypeName = $phpType->name;
+        $phpTypeName = $phpType->getName();
 
         $phpTypeSchema = [
             'type' => 'object',
@@ -126,10 +127,10 @@ final class ObjectPhpTypeSchemaResolver implements
         return -100;
     }
 
-    public function resolvePhpTypeSchemaName(Type $phpType, Reflector $phpTypeHolder): string
+    public function resolvePhpTypeSchemaName(TypeInterface $phpType, Reflector $phpTypeHolder): string
     {
         /** @var class-string $className */
-        $className = $phpType->name;
+        $className = $phpType->getName();
         $classReflection = new ReflectionClass($className);
 
         /** @var list<ReflectionAttribute<SchemaNameInterface>> $annotations */

--- a/src/OpenApi/PhpTypeSchemaResolver/ObjectPhpTypeSchemaResolver.php
+++ b/src/OpenApi/PhpTypeSchemaResolver/ObjectPhpTypeSchemaResolver.php
@@ -21,7 +21,7 @@ use ReflectionProperty;
 use Reflector;
 use Sunrise\Http\Router\OpenApi\Annotation\IgnorePropertyInterface;
 use Sunrise\Http\Router\OpenApi\Annotation\PropertyNameInterface;
-use Sunrise\Http\Router\OpenApi\Annotation\SchemaName;
+use Sunrise\Http\Router\OpenApi\Annotation\SchemaNameInterface;
 use Sunrise\Http\Router\OpenApi\Exception\UnsupportedPhpTypeException;
 use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaNameResolverInterface;
 use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaResolverInterface;
@@ -132,11 +132,10 @@ final class ObjectPhpTypeSchemaResolver implements
         $className = $phpType->name;
         $classReflection = new ReflectionClass($className);
 
-        /** @var list<ReflectionAttribute<SchemaName>> $annotations */
-        $annotations = $classReflection->getAttributes(SchemaName::class, ReflectionAttribute::IS_INSTANCEOF);
+        /** @var list<ReflectionAttribute<SchemaNameInterface>> $annotations */
+        $annotations = $classReflection->getAttributes(SchemaNameInterface::class, ReflectionAttribute::IS_INSTANCEOF);
         if (isset($annotations[0])) {
-            $annotation = $annotations[0]->newInstance();
-            return $annotation->value;
+            return $annotations[0]->newInstance()->getSchemaName();
         }
 
         return $classReflection->getShortName();

--- a/src/OpenApi/PhpTypeSchemaResolver/ObjectPhpTypeSchemaResolver.php
+++ b/src/OpenApi/PhpTypeSchemaResolver/ObjectPhpTypeSchemaResolver.php
@@ -19,6 +19,8 @@ use ReflectionClass;
 use ReflectionException;
 use ReflectionProperty;
 use Reflector;
+use Sunrise\Http\Router\OpenApi\Annotation\IgnorePropertyInterface;
+use Sunrise\Http\Router\OpenApi\Annotation\PropertyNameInterface;
 use Sunrise\Http\Router\OpenApi\Annotation\SchemaName;
 use Sunrise\Http\Router\OpenApi\Exception\UnsupportedPhpTypeException;
 use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaNameResolverInterface;
@@ -142,7 +144,8 @@ final class ObjectPhpTypeSchemaResolver implements
 
     private static function isIgnoredProperty(ReflectionProperty $property): bool
     {
-        return $property->getAttributes(Ignore::class) !== [];
+        return $property->getAttributes(Ignore::class) !== []
+            || $property->getAttributes(IgnorePropertyInterface::class, ReflectionAttribute::IS_INSTANCEOF) !== [];
     }
 
     private static function getPropertyName(ReflectionProperty $property): string
@@ -152,6 +155,13 @@ final class ObjectPhpTypeSchemaResolver implements
         if (isset($annotations[0])) {
             $annotation = $annotations[0]->newInstance();
             return $annotation->value;
+        }
+
+        /** @var list<ReflectionAttribute<PropertyNameInterface>> $annotations */
+        $annotations = $property->getAttributes(PropertyNameInterface::class, ReflectionAttribute::IS_INSTANCEOF);
+        if (isset($annotations[0])) {
+            $annotation = $annotations[0]->newInstance();
+            return $annotation->getPropertyName();
         }
 
         return $property->name;

--- a/src/OpenApi/PhpTypeSchemaResolver/RamseyUuidPhpTypeSchemaResolver.php
+++ b/src/OpenApi/PhpTypeSchemaResolver/RamseyUuidPhpTypeSchemaResolver.php
@@ -18,21 +18,22 @@ use Reflector;
 use Sunrise\Http\Router\OpenApi\Exception\UnsupportedPhpTypeException;
 use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaResolverInterface;
 use Sunrise\Http\Router\OpenApi\Type;
+use Sunrise\Http\Router\OpenApi\TypeInterface;
 
 /**
  * @since 3.0.0
  */
 final class RamseyUuidPhpTypeSchemaResolver implements OpenApiPhpTypeSchemaResolverInterface
 {
-    public function supportsPhpType(Type $phpType, Reflector $phpTypeHolder): bool
+    public function supportsPhpType(TypeInterface $phpType, Reflector $phpTypeHolder): bool
     {
-        return $phpType->name === UuidInterface::class;
+        return $phpType->getName() === UuidInterface::class;
     }
 
     /**
      * @inheritDoc
      */
-    public function resolvePhpTypeSchema(Type $phpType, Reflector $phpTypeHolder): array
+    public function resolvePhpTypeSchema(TypeInterface $phpType, Reflector $phpTypeHolder): array
     {
         $this->supportsPhpType($phpType, $phpTypeHolder) or throw new UnsupportedPhpTypeException();
 

--- a/src/OpenApi/PhpTypeSchemaResolver/StreamPhpTypeSchemaResolver.php
+++ b/src/OpenApi/PhpTypeSchemaResolver/StreamPhpTypeSchemaResolver.php
@@ -18,21 +18,22 @@ use Reflector;
 use Sunrise\Http\Router\OpenApi\Exception\UnsupportedPhpTypeException;
 use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaResolverInterface;
 use Sunrise\Http\Router\OpenApi\Type;
+use Sunrise\Http\Router\OpenApi\TypeInterface;
 
 /**
  * @since 3.0.0
  */
 final class StreamPhpTypeSchemaResolver implements OpenApiPhpTypeSchemaResolverInterface
 {
-    public function supportsPhpType(Type $phpType, Reflector $phpTypeHolder): bool
+    public function supportsPhpType(TypeInterface $phpType, Reflector $phpTypeHolder): bool
     {
-        return $phpType->name === StreamInterface::class;
+        return $phpType->getName() === StreamInterface::class;
     }
 
     /**
      * @inheritDoc
      */
-    public function resolvePhpTypeSchema(Type $phpType, Reflector $phpTypeHolder): array
+    public function resolvePhpTypeSchema(TypeInterface $phpType, Reflector $phpTypeHolder): array
     {
         $this->supportsPhpType($phpType, $phpTypeHolder) or throw new UnsupportedPhpTypeException();
 

--- a/src/OpenApi/PhpTypeSchemaResolver/StringPhpTypeSchemaResolver.php
+++ b/src/OpenApi/PhpTypeSchemaResolver/StringPhpTypeSchemaResolver.php
@@ -20,21 +20,22 @@ use SensitiveParameter;
 use Sunrise\Http\Router\OpenApi\Exception\UnsupportedPhpTypeException;
 use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaResolverInterface;
 use Sunrise\Http\Router\OpenApi\Type;
+use Sunrise\Http\Router\OpenApi\TypeInterface;
 
 /**
  * @since 3.0.0
  */
 final class StringPhpTypeSchemaResolver implements OpenApiPhpTypeSchemaResolverInterface
 {
-    public function supportsPhpType(Type $phpType, Reflector $phpTypeHolder): bool
+    public function supportsPhpType(TypeInterface $phpType, Reflector $phpTypeHolder): bool
     {
-        return $phpType->name === Type::PHP_TYPE_NAME_STRING;
+        return $phpType->getName() === Type::PHP_TYPE_NAME_STRING;
     }
 
     /**
      * @inheritDoc
      */
-    public function resolvePhpTypeSchema(Type $phpType, Reflector $phpTypeHolder): array
+    public function resolvePhpTypeSchema(TypeInterface $phpType, Reflector $phpTypeHolder): array
     {
         $this->supportsPhpType($phpType, $phpTypeHolder) or throw new UnsupportedPhpTypeException();
 

--- a/src/OpenApi/PhpTypeSchemaResolver/SymfonyUidPhpTypeSchemaResolver.php
+++ b/src/OpenApi/PhpTypeSchemaResolver/SymfonyUidPhpTypeSchemaResolver.php
@@ -17,6 +17,7 @@ use Reflector;
 use Sunrise\Http\Router\OpenApi\Exception\UnsupportedPhpTypeException;
 use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaResolverInterface;
 use Sunrise\Http\Router\OpenApi\Type;
+use Sunrise\Http\Router\OpenApi\TypeInterface;
 use Symfony\Component\Uid\AbstractUid;
 use Symfony\Component\Uid\Uuid;
 
@@ -28,15 +29,15 @@ use function is_subclass_of;
  */
 final class SymfonyUidPhpTypeSchemaResolver implements OpenApiPhpTypeSchemaResolverInterface
 {
-    public function supportsPhpType(Type $phpType, Reflector $phpTypeHolder): bool
+    public function supportsPhpType(TypeInterface $phpType, Reflector $phpTypeHolder): bool
     {
-        return is_subclass_of($phpType->name, AbstractUid::class);
+        return is_subclass_of($phpType->getName(), AbstractUid::class);
     }
 
     /**
      * @inheritDoc
      */
-    public function resolvePhpTypeSchema(Type $phpType, Reflector $phpTypeHolder): array
+    public function resolvePhpTypeSchema(TypeInterface $phpType, Reflector $phpTypeHolder): array
     {
         $this->supportsPhpType($phpType, $phpTypeHolder) or throw new UnsupportedPhpTypeException();
 
@@ -44,7 +45,7 @@ final class SymfonyUidPhpTypeSchemaResolver implements OpenApiPhpTypeSchemaResol
             'type' => Type::OAS_TYPE_NAME_STRING,
         ];
 
-        if (is_a($phpType->name, Uuid::class, true)) {
+        if (is_a($phpType->getName(), Uuid::class, true)) {
             $phpTypeSchema['format'] = 'uuid';
         }
 

--- a/src/OpenApi/PhpTypeSchemaResolver/TimestampPhpTypeSchemaResolver.php
+++ b/src/OpenApi/PhpTypeSchemaResolver/TimestampPhpTypeSchemaResolver.php
@@ -18,6 +18,7 @@ use ReflectionAttribute;
 use ReflectionParameter;
 use ReflectionProperty;
 use Reflector;
+use Sunrise\Http\Router\OpenApi\Annotation\TimestampFormatInterface;
 use Sunrise\Http\Router\OpenApi\Exception\UnsupportedPhpTypeException;
 use Sunrise\Http\Router\OpenApi\OpenApiConfiguration;
 use Sunrise\Http\Router\OpenApi\OpenApiConfigurationAwareInterface;
@@ -65,6 +66,17 @@ final class TimestampPhpTypeSchemaResolver implements
             if (isset($annotations[0])) {
                 $annotation = $annotations[0]->newInstance();
                 $timestampFormat = $annotation->value;
+            }
+
+            /** @var list<ReflectionAttribute<TimestampFormatInterface>> $annotations */
+            $annotations = $phpTypeHolder->getAttributes(
+                TimestampFormatInterface::class,
+                ReflectionAttribute::IS_INSTANCEOF,
+            );
+
+            if (isset($annotations[0])) {
+                $annotation = $annotations[0]->newInstance();
+                $timestampFormat = $annotation->getTimestampFormat();
             }
         }
 

--- a/src/OpenApi/PhpTypeSchemaResolver/TimestampPhpTypeSchemaResolver.php
+++ b/src/OpenApi/PhpTypeSchemaResolver/TimestampPhpTypeSchemaResolver.php
@@ -24,6 +24,7 @@ use Sunrise\Http\Router\OpenApi\OpenApiConfiguration;
 use Sunrise\Http\Router\OpenApi\OpenApiConfigurationAwareInterface;
 use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaResolverInterface;
 use Sunrise\Http\Router\OpenApi\Type;
+use Sunrise\Http\Router\OpenApi\TypeInterface;
 use Sunrise\Hydrator\Annotation\Format;
 
 use function date;
@@ -43,15 +44,15 @@ final class TimestampPhpTypeSchemaResolver implements
         $this->openApiConfiguration = $openApiConfiguration;
     }
 
-    public function supportsPhpType(Type $phpType, Reflector $phpTypeHolder): bool
+    public function supportsPhpType(TypeInterface $phpType, Reflector $phpTypeHolder): bool
     {
-        return is_a($phpType->name, DateTimeImmutable::class, true);
+        return is_a($phpType->getName(), DateTimeImmutable::class, true);
     }
 
     /**
      * @inheritDoc
      */
-    public function resolvePhpTypeSchema(Type $phpType, Reflector $phpTypeHolder): array
+    public function resolvePhpTypeSchema(TypeInterface $phpType, Reflector $phpTypeHolder): array
     {
         $this->supportsPhpType($phpType, $phpTypeHolder) or throw new UnsupportedPhpTypeException();
 

--- a/src/OpenApi/PhpTypeSchemaResolver/TimezonePhpTypeSchemaResolver.php
+++ b/src/OpenApi/PhpTypeSchemaResolver/TimezonePhpTypeSchemaResolver.php
@@ -19,6 +19,7 @@ use Sunrise\Http\Router\OpenApi\Exception\UnsupportedPhpTypeException;
 use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaNameResolverInterface;
 use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaResolverInterface;
 use Sunrise\Http\Router\OpenApi\Type;
+use Sunrise\Http\Router\OpenApi\TypeInterface;
 
 /**
  * @since 3.0.0
@@ -451,15 +452,15 @@ final class TimezonePhpTypeSchemaResolver implements
         'UTC',
     ];
 
-    public function supportsPhpType(Type $phpType, Reflector $phpTypeHolder): bool
+    public function supportsPhpType(TypeInterface $phpType, Reflector $phpTypeHolder): bool
     {
-        return $phpType->name === DateTimeZone::class;
+        return $phpType->getName() === DateTimeZone::class;
     }
 
     /**
      * @inheritDoc
      */
-    public function resolvePhpTypeSchema(Type $phpType, Reflector $phpTypeHolder): array
+    public function resolvePhpTypeSchema(TypeInterface $phpType, Reflector $phpTypeHolder): array
     {
         $this->supportsPhpType($phpType, $phpTypeHolder) or throw new UnsupportedPhpTypeException();
 
@@ -474,7 +475,7 @@ final class TimezonePhpTypeSchemaResolver implements
         return 0;
     }
 
-    public function resolvePhpTypeSchemaName(Type $phpType, Reflector $phpTypeHolder): string
+    public function resolvePhpTypeSchemaName(TypeInterface $phpType, Reflector $phpTypeHolder): string
     {
         return DateTimeZone::class;
     }

--- a/src/OpenApi/Type.php
+++ b/src/OpenApi/Type.php
@@ -16,7 +16,7 @@ namespace Sunrise\Http\Router\OpenApi;
 /**
  * @since 3.0.0
  */
-final class Type
+final class Type implements TypeInterface
 {
     public const PHP_TYPE_NAME_VOID = 'void';
     public const PHP_TYPE_NAME_NULL = 'null';
@@ -36,13 +36,18 @@ final class Type
     public const OAS_TYPE_NAME_OBJECT = 'object';
 
     public function __construct(
-        public readonly string $name,
-        public readonly bool $allowsNull = false,
+        private readonly string $name,
+        private readonly bool $allowsNull = false,
     ) {
     }
 
-    public function is(string $typeName): bool
+    public function getName(): string
     {
-        return $this->name === $typeName;
+        return $this->name;
+    }
+
+    public function allowsNull(): bool
+    {
+        return $this->allowsNull;
     }
 }

--- a/src/OpenApi/TypeFactory.php
+++ b/src/OpenApi/TypeFactory.php
@@ -21,12 +21,12 @@ use ReflectionType;
  */
 final class TypeFactory
 {
-    public static function mixedPhpType(): Type
+    public static function mixedPhpType(): TypeInterface
     {
         return new Type(Type::PHP_TYPE_NAME_MIXED, allowsNull: true);
     }
 
-    public static function fromPhpTypeReflection(?ReflectionType $phpTypeReflection): Type
+    public static function fromPhpTypeReflection(?ReflectionType $phpTypeReflection): TypeInterface
     {
         if ($phpTypeReflection === null) {
             return self::mixedPhpType();

--- a/src/OpenApi/TypeInterface.php
+++ b/src/OpenApi/TypeInterface.php
@@ -13,15 +13,12 @@ declare(strict_types=1);
 
 namespace Sunrise\Http\Router\OpenApi;
 
-use Reflector;
-
 /**
- * @since 3.0.0
+ * @since 3.3.0
  */
-interface OpenApiPhpTypeSchemaNameResolverInterface
+interface TypeInterface
 {
-    /**
-     * Please note that nullable should be ignored.
-     */
-    public function resolvePhpTypeSchemaName(TypeInterface $phpType, Reflector $phpTypeHolder): string;
+    public function getName(): string;
+
+    public function allowsNull(): bool;
 }

--- a/src/RequestHandlerResolver.php
+++ b/src/RequestHandlerResolver.php
@@ -60,10 +60,9 @@ final class RequestHandlerResolver implements RequestHandlerResolverInterface
 
         // https://github.com/php/php-src/blob/3ed526441400060aa4e618b91b3352371fcd02a8/Zend/zend_API.c#L3884-L3932
         if (is_array($reference) && is_callable($reference, true)) {
-            // @phpstan-ignore-next-line
             /** @var array{0: class-string|object, 1: string} $reference */
 
-            if (is_string($reference[0])) {
+            if (is_string($reference[0])) { // @phpstan-ignore-line varTag.nativeType
                 $reference[0] = $this->classResolver->resolveClass($reference[0]);
             }
 

--- a/src/RequestHandlerResolver.php
+++ b/src/RequestHandlerResolver.php
@@ -60,6 +60,7 @@ final class RequestHandlerResolver implements RequestHandlerResolverInterface
 
         // https://github.com/php/php-src/blob/3ed526441400060aa4e618b91b3352371fcd02a8/Zend/zend_API.c#L3884-L3932
         if (is_array($reference) && is_callable($reference, true)) {
+            // @phpstan-ignore-next-line
             /** @var array{0: class-string|object, 1: string} $reference */
 
             if (is_string($reference[0])) {

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -73,7 +73,7 @@ final class ServerRequest implements ServerRequestInterface
 
         [$identifier] = reset($values);
 
-        return new MediaType($identifier);
+        return MediaType::create($identifier);
     }
 
     /**
@@ -92,7 +92,7 @@ final class ServerRequest implements ServerRequestInterface
         ));
 
         foreach ($values as [$identifier]) {
-            yield new MediaType($identifier);
+            yield MediaType::create($identifier);
         }
     }
 

--- a/tests/Fixture/Tests/PhpDocArrayFixture.php
+++ b/tests/Fixture/Tests/PhpDocArrayFixture.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sunrise\Http\Router\Tests\Fixture\Tests;
+
+use DateTimeImmutable;
+use Sunrise\Hydrator\Annotation\Subtype;
+
+final class PhpDocArrayFixture
+{
+    /** @var PhpDocArrayItemFixture[] */
+    public array $items;
+
+    /** @var list<PhpDocArrayItemFixture> */
+    public array $listItems;
+
+    /** @var array<string, PhpDocArrayItemFixture|null> */
+    public array $nullableItems;
+
+    /** @var array<array-key, PhpDocArrayItemFixture>|null */
+    public array $nullableArray;
+
+    /** @var array<array-key, PhpDocArrayItemFixture|DateTimeImmutable> */
+    public array $compoundItems;
+
+    /** @var PhpDocArrayItemFixture[] */
+    #[Subtype('string', limit: 2)]
+    public array $subtypedItems;
+
+    /** @var array */
+    public array $mixedItems;
+
+    public array $untypedItems;
+}

--- a/tests/Fixture/Tests/PhpDocArrayItemFixture.php
+++ b/tests/Fixture/Tests/PhpDocArrayItemFixture.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sunrise\Http\Router\Tests\Fixture\Tests;
+
+final class PhpDocArrayItemFixture
+{
+}

--- a/tests/OpenApi/PhpTypeSchemaResolver/ArrayPhpTypeSchemaResolverTest.php
+++ b/tests/OpenApi/PhpTypeSchemaResolver/ArrayPhpTypeSchemaResolverTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sunrise\Http\Router\Tests\OpenApi\PhpTypeSchemaResolver;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use Sunrise\Http\Router\OpenApi\Exception\UnsupportedPhpTypeException;
+use Sunrise\Http\Router\OpenApi\OpenApiPhpTypeSchemaResolverManagerInterface;
+use Sunrise\Http\Router\OpenApi\PhpTypeSchemaResolver\ArrayPhpTypeSchemaResolver;
+use Sunrise\Http\Router\OpenApi\Type;
+use Sunrise\Http\Router\OpenApi\TypeInterface;
+use Sunrise\Http\Router\Tests\Fixture\Tests\PhpDocArrayFixture;
+use Sunrise\Http\Router\Tests\Fixture\Tests\PhpDocArrayItemFixture;
+
+final class ArrayPhpTypeSchemaResolverTest extends TestCase
+{
+    private OpenApiPhpTypeSchemaResolverManagerInterface&MockObject $mockedOpenApiPhpTypeSchemaResolverManager;
+
+    protected function setUp(): void
+    {
+        $this->mockedOpenApiPhpTypeSchemaResolverManager = $this
+            ->createMock(OpenApiPhpTypeSchemaResolverManagerInterface::class);
+    }
+
+    public function testResolvePhpTypeSchema(): void
+    {
+        $this->mockedOpenApiPhpTypeSchemaResolverManager->expects(self::never())->method('resolvePhpTypeSchema');
+        $property = $this->createProperty('untypedItems');
+        $phpTypeSchema = $this->createResolver()->resolvePhpTypeSchema(new Type('array'), $property);
+        self::assertSame(['type' => 'array'], $phpTypeSchema);
+    }
+
+    public function testSubtype(): void
+    {
+        $property = $this->createProperty('subtypedItems');
+        $this->mockItemType($property, 'string', ['type' => 'string']);
+        $phpTypeSchema = $this->createResolver()->resolvePhpTypeSchema(new Type('array'), $property);
+        self::assertSame([
+            'type' => 'array',
+            'items' => ['type' => 'string'],
+            'maxItems' => 2,
+        ], $phpTypeSchema);
+    }
+
+    public function testVar(): void
+    {
+        $property = $this->createProperty('items');
+        $this->mockItemType($property, PhpDocArrayItemFixture::class);
+        $phpTypeSchema = $this->createResolver()->resolvePhpTypeSchema(new Type('array'), $property);
+        self::assertSame([
+            'type' => 'array',
+            'items' => ['type' => 'object'],
+        ], $phpTypeSchema);
+    }
+
+    public function testListVar(): void
+    {
+        $property = $this->createProperty('listItems');
+        $this->mockItemType($property, PhpDocArrayItemFixture::class);
+        $phpTypeSchema = $this->createResolver()->resolvePhpTypeSchema(new Type('array'), $property);
+        self::assertSame([
+            'type' => 'array',
+            'items' => ['type' => 'object'],
+        ], $phpTypeSchema);
+    }
+
+    public function testNullableVar(): void
+    {
+        $property = $this->createProperty('nullableItems');
+        $this->mockItemType($property, PhpDocArrayItemFixture::class, allowsNull: true);
+        $phpTypeSchema = $this->createResolver()->resolvePhpTypeSchema(new Type('array'), $property);
+        self::assertSame([
+            'type' => 'array',
+            'items' => ['type' => 'object'],
+        ], $phpTypeSchema);
+    }
+
+    public function testNullableArrayVar(): void
+    {
+        $property = $this->createProperty('nullableArray');
+        $this->mockItemType($property, PhpDocArrayItemFixture::class);
+        $phpTypeSchema = $this->createResolver()->resolvePhpTypeSchema(new Type('array'), $property);
+        self::assertSame([
+            'type' => 'array',
+            'items' => ['type' => 'object'],
+        ], $phpTypeSchema);
+    }
+
+    public function testMixedVar(): void
+    {
+        $property = $this->createProperty('mixedItems');
+        $phpTypeSchema = $this->createResolver()->resolvePhpTypeSchema(new Type('array'), $property);
+        self::assertSame(['type' => 'array', 'items' => []], $phpTypeSchema);
+    }
+
+    public function testCompoundVar(): void
+    {
+        $property = $this->createProperty('compoundItems');
+        $phpTypeSchema = $this->createResolver()->resolvePhpTypeSchema(new Type('array'), $property);
+        self::assertSame(['type' => 'array', 'items' => []], $phpTypeSchema);
+    }
+
+    public function testUnsupportedPhpType(): void
+    {
+        $this->expectException(UnsupportedPhpTypeException::class);
+        $this->createResolver()->resolvePhpTypeSchema(new Type('string'), $this->createProperty('items'));
+    }
+
+    public function testWeight(): void
+    {
+        self::assertSame(0, $this->createResolver()->getWeight());
+    }
+
+    private function createResolver(): ArrayPhpTypeSchemaResolver
+    {
+        $resolver = new ArrayPhpTypeSchemaResolver();
+        $resolver->setOpenApiPhpTypeSchemaResolverManager($this->mockedOpenApiPhpTypeSchemaResolverManager);
+        return $resolver;
+    }
+
+    private function createProperty(string $name): ReflectionProperty
+    {
+        return new ReflectionProperty(PhpDocArrayFixture::class, $name);
+    }
+
+    /**
+     * @param array<array-key, mixed> $phpTypeSchema
+     */
+    private function mockItemType(
+        ReflectionProperty $property,
+        string $name,
+        array $phpTypeSchema = ['type' => 'object'],
+        bool $allowsNull = false,
+    ): void {
+        $this->mockedOpenApiPhpTypeSchemaResolverManager
+            ->expects(self::once())
+            ->method('resolvePhpTypeSchema')
+            ->with(self::callback(static fn(TypeInterface $type): bool => $type->getName() === $name && $type->allowsNull() === $allowsNull), $property)
+            ->willReturn($phpTypeSchema);
+    }
+}

--- a/tests/OpenApi/PhpTypeSchemaResolver/ArrayPhpTypeSchemaResolverTest.php
+++ b/tests/OpenApi/PhpTypeSchemaResolver/ArrayPhpTypeSchemaResolverTest.php
@@ -38,11 +38,7 @@ final class ArrayPhpTypeSchemaResolverTest extends TestCase
         $property = $this->createProperty('subtypedItems');
         $this->mockItemType($property, 'string', ['type' => 'string']);
         $phpTypeSchema = $this->createResolver()->resolvePhpTypeSchema(new Type('array'), $property);
-        self::assertSame([
-            'type' => 'array',
-            'items' => ['type' => 'string'],
-            'maxItems' => 2,
-        ], $phpTypeSchema);
+        self::assertSame(['type' => 'array', 'items' => ['type' => 'string'], 'maxItems' => 2], $phpTypeSchema);
     }
 
     public function testVar(): void
@@ -50,10 +46,7 @@ final class ArrayPhpTypeSchemaResolverTest extends TestCase
         $property = $this->createProperty('items');
         $this->mockItemType($property, PhpDocArrayItemFixture::class);
         $phpTypeSchema = $this->createResolver()->resolvePhpTypeSchema(new Type('array'), $property);
-        self::assertSame([
-            'type' => 'array',
-            'items' => ['type' => 'object'],
-        ], $phpTypeSchema);
+        self::assertSame(['type' => 'array', 'items' => ['type' => 'object']], $phpTypeSchema);
     }
 
     public function testListVar(): void
@@ -61,10 +54,7 @@ final class ArrayPhpTypeSchemaResolverTest extends TestCase
         $property = $this->createProperty('listItems');
         $this->mockItemType($property, PhpDocArrayItemFixture::class);
         $phpTypeSchema = $this->createResolver()->resolvePhpTypeSchema(new Type('array'), $property);
-        self::assertSame([
-            'type' => 'array',
-            'items' => ['type' => 'object'],
-        ], $phpTypeSchema);
+        self::assertSame(['type' => 'array', 'items' => ['type' => 'object']], $phpTypeSchema);
     }
 
     public function testNullableVar(): void
@@ -72,10 +62,7 @@ final class ArrayPhpTypeSchemaResolverTest extends TestCase
         $property = $this->createProperty('nullableItems');
         $this->mockItemType($property, PhpDocArrayItemFixture::class, allowsNull: true);
         $phpTypeSchema = $this->createResolver()->resolvePhpTypeSchema(new Type('array'), $property);
-        self::assertSame([
-            'type' => 'array',
-            'items' => ['type' => 'object'],
-        ], $phpTypeSchema);
+        self::assertSame(['type' => 'array', 'items' => ['type' => 'object']], $phpTypeSchema);
     }
 
     public function testNullableArrayVar(): void
@@ -83,10 +70,7 @@ final class ArrayPhpTypeSchemaResolverTest extends TestCase
         $property = $this->createProperty('nullableArray');
         $this->mockItemType($property, PhpDocArrayItemFixture::class);
         $phpTypeSchema = $this->createResolver()->resolvePhpTypeSchema(new Type('array'), $property);
-        self::assertSame([
-            'type' => 'array',
-            'items' => ['type' => 'object'],
-        ], $phpTypeSchema);
+        self::assertSame(['type' => 'array', 'items' => ['type' => 'object']], $phpTypeSchema);
     }
 
     public function testMixedVar(): void


### PR DESCRIPTION
## What changed

This PR significantly reworks the OpenAPI part of `sunrise/http-router`.

The main goal of these changes is to make the OpenAPI API more reusable and less tightly coupled to HTTP Router itself. The OpenAPI generator is still shipped together with the router, but its internal architecture is now less dependent on a specific routing implementation and can be used as a standalone foundation for integrations with other frameworks.

One practical result of this refactoring is a separate Symfony bundle:

https://github.com/sunrise-studio-development/symfony-openapi

It uses the OpenAPI API from `sunrise/http-router`, while adding full support for Symfony routes and Symfony attributes. This is a good example of how the OpenAPI layer can now be extended and reused outside the main HTTP Router.

## `@var` support for output/view objects

For users who use `sunrise/http-router` as their router, this PR also adds support for PHPDoc `@var` annotations when generating OpenAPI schemas for output/view objects.

Previously, describing array item types in OpenAPI required using the `Subtype` attribute from `sunrise/hydrator`. This was not always convenient, especially for response objects where `Subtype` was needed not for data hydration, but only to produce a correct OpenAPI schema.

Now array item types in view/output objects can be described with PHPDoc:

```php
/**
 * @var UserView[]
 */
public array $users;
```

or with similar PHPDoc types supported by the parser.

`Subtype` is still relevant for input DTOs, where it is required for correct hydrator behavior. But response objects no longer need to use `Subtype` only for OpenAPI generation.

## Why this matters

These changes make the OpenAPI part of the package more flexible:

* the OpenAPI API is now easier to use outside `sunrise/http-router`;
* integrations with other frameworks are easier to build;
* output/view objects no longer need an extra dependency on hydrator attributes just for documentation;
* users can describe array item types in the familiar PHPDoc way with `@var`.

Overall, the existing HTTP Router behavior remains compatible for current users, while the OpenAPI layer becomes more standalone and extensible.
